### PR TITLE
Add FreeBSD support

### DIFF
--- a/stderred.c
+++ b/stderred.c
@@ -1,7 +1,11 @@
 #define write ye_olde_write
 #include <unistd.h>
 #include <string.h>
+#ifndef __FreeBSD__
 #include <alloca.h>
+#else
+extern char *alloca(size_t);
+#endif
 
 #include <dlfcn.h>
 


### PR DESCRIPTION
On FreeBSD, alloca.h doesn't exist and alloca is declared in stdlib. The diff steps around that so this can be compiled on FreeBSD. I tested this on amd64
