### PR TITLE
Fix incorrect hardcoded requirement for libdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ Important: In all cases below make sure that path to `libstderred.so` is absolut
 
 ### Linux and FreeBSD
 
-Make sure you have gcc toolchain required for compilation installed:
+Make sure you have cmake and the gcc toolchain required for compilation installed:
 
     # Ubuntu
     sudo apt-get install build-essential cmake
 
     # Fedora
     sudo yum install make cmake gcc gcc-c++
+
+    # FreeBSD
+    pkg install cmake
 
 Build:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,11 +73,11 @@ add_library(test_stderred SHARED mocks.c ${stderred_sources})
 add_executable(test_runner test.c)
 
 add_library(polyfill SHARED polyfill.c)
-target_link_libraries(test_runner dl polyfill)
+target_link_libraries(test_runner ${CMAKE_DL_LIBS} polyfill)
 
 if (NOT APPLE)
-  target_link_libraries(stderred dl)
-  target_link_libraries(test_stderred dl)
+  target_link_libraries(stderred ${CMAKE_DL_LIBS})
+  target_link_libraries(test_stderred ${CMAKE_DL_LIBS})
 endif(NOT APPLE)
 
 install(TARGETS stderred DESTINATION lib)


### PR DESCRIPTION
Not all platforms, for example FreeBSD, require linking against libdl.
Cmake provides the variable CMAKE_DL_LIBS which should contain
platform-appropriate libraries. This patch replaces the use of 'dl'
with this variable, and updates the documentation to reflect the actual
requirements for compilation on FreeBSD.
