### PR TITLE
Fix Makefile target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-all: test
+all: build
 
-build: clean
+build:
 	mkdir build && cd build && cmake ../src && make
 
 32: clean32
@@ -21,8 +21,8 @@ clean64:
 test: build
 	cd build && make test
 
-clean:
-	rm -rf build lib lib64
+clean: clean32 clean64
+	rm -rf build
 
 dist_prepare: test
 	mkdir -p usr/share/doc/stderred && cp README.md usr/share/doc/stderred/


### PR DESCRIPTION
https://www.gnu.org/prep/standards/html_node/Standard-Targets.html

* `make all` does a build
* `make all` doesn't require a clean
* Small syntactic improvement to `make clean`