### PR TITLE
Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ clean64:
 test: build
 	cd build && make test
 
+install: build
+	cd build && make install
+
 clean: clean32 clean64
 	rm -rf build
 


### PR DESCRIPTION
CMake provides a `make install` target by default. Simply run these two commands to make and install to `/usr/local`:
```
make && sudo make install
```
NOTE: don't merge this without merging #42! Otherwise the build (and tests) will have to run twice and will run as root the second time.