### PR TITLE
Fix line truncation on printing null character via *printf() functions

### DIFF
--- a/src/stderred.c
+++ b/src/stderred.c
@@ -147,8 +147,9 @@ int FUNC(fputs_unlocked)(const char *str, FILE *stream) {
 int FUNC(vfprintf)(FILE *stream, const char *format, va_list ap) {
   char *buf = NULL;
 
-  if (vasprintf(&buf, format, ap) > 0) {
-    int result = FUNC(fwrite)(buf, sizeof(char), strlen(buf)/sizeof(char), stream);
+  int nprinted = vasprintf(&buf, format, ap);
+  if (nprinted > 0) {
+    int result = FUNC(fwrite)(buf, sizeof(char), nprinted, stream);
     free(buf);
     return result;
   } else {
@@ -170,8 +171,9 @@ int FUNC(fprintf_unlocked)(FILE *stream, const char *format, ...) {
   char *buf = NULL;
   int result = -1;
 
-  if ( vasprintf(&buf, format, args) > 0) {
-    result = FUNC(fwrite_unlocked)(buf, sizeof(char), strlen(buf)/sizeof(char), stream);
+  int nprinted = vasprintf(&buf, format, args);
+  if (nprinted > 0) {
+    result = FUNC(fwrite_unlocked)(buf, sizeof(char), nprinted, stream);
     free(buf);
   }
 


### PR DESCRIPTION
Using `strlen()` in these two places is bad idea because it stops at the first `'\0'` and only prefix of formatted string is printed.

I tried to update tests, but couldn't embed null character in cmake string and those in captured output of `printf` seem to be completely ignored by it either on input or in regular expression engine...
