### PR TITLE
Rename init() to avoid name collision with running program

### DIFF
--- a/src/mocks.c
+++ b/src/mocks.c
@@ -2,7 +2,7 @@
 #include "mocks.h"
 
 // Signature of library initialization function
-void init();
+void init_stderred();
 
 extern char *start_color_code;
 extern size_t start_color_code_size;
@@ -27,7 +27,7 @@ int isatty(int fildes) {
 }
 
 void init_mocks(struct stderred *stderred) {
-  stderred->init = &init;
+  stderred->init = &init_stderred;
   stderred->reset = &reset_stderred;
   stderred->has_valid_env = &is_valid_env;
   stderred->mock_tty = &mock_tty;

--- a/src/stderred.c
+++ b/src/stderred.c
@@ -36,7 +36,7 @@ size_t end_color_code_size;
 #define COLORIZE(fd) (is_valid_env && fd == STDERR_FILENO)
 bool is_valid_env = false;
 
-__attribute__((constructor)) void init() {
+__attribute__((constructor)) void init_stderred() {
   if (!strcmp("bash", PROGRAM_NAME)) return;
   if (!isatty(STDERR_FILENO)) return;
 


### PR DESCRIPTION
I've been debugging a bizarre issue recently with the panel program [tint2](https://gitlab.com/o9000/tint2), that I have traced to my use of stderred. When I start the tint2 panel, mouse clicks were being ignored half the time, and it turned out there were two copies of the panel running that were interfering with each other. Upon digging into the source code, it turns out that tint2 has a function called `init()`, which was being called twice, when it should only be called once, leading to the incorrect behaviour. One of these calls was even occurring before the program's `main()` method! This hinted that it was not a bug in tint2 and led me to remember what I had in my LD_PRELOAD.

Upon testing, I've determined that this problem doesn't occur when I am not setting LD_PRELOAD to use stderred. It appears to be a name collision with the constructor of stderred, which is also called `init()`. I'm not sure under what conditions it is triggered (I tried to make a minimal C program to demonstrate the issue, but was not able to), but basically the `init()` function from tint2 was being called instead of stderred's constructor, resulting in tint2 initialising itself twice and not working correctly.

This pull request renames `init()` to `stderred_init()`. With this change, having stderred in LD_PRELOAD doesn't affect the program tint2 anymore.

I am assuming that the fact that `init()` is a constructor makes it special and that the other functions are not at risk of name collisions (other than the ones actually intended to replace libc calls), but if this assumption is not correct then perhaps other functions should be name-munged as well