### PR TITLE
using special enter/leave stderr escape sequence on DomTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 stderr in red.
 
+This fork adds improved support for [DomTerm](https://domterm.org):
+If the `DOMTERM` environment variable is set, emits the DomTerm-specfic
+escape sequendes for entering/exiting stderr.  This works better if there
+are other escape sequences in stderr; it also allows more flexible styling.
+
 ## About
 
 stderred hooks on write() and a family of stream functions (fwrite, fprintf,

--- a/src/stderred.c
+++ b/src/stderred.c
@@ -55,7 +55,12 @@ __attribute__((constructor)) void init() {
 
   start_color_code = getenv("STDERRED_ESC_CODE");
   if (start_color_code == NULL) {
-    start_color_code = "\x1b[31m";
+      bool isDomTerm = getenv("DOMTERM") != NULL;
+      if (isDomTerm) {
+          start_color_code = "\033[12u";
+          end_color_code = "\033[11u";
+      } else
+          start_color_code = "\x1b[31m";
   }
   start_color_code_size = strlen(start_color_code);
   end_color_code_size = strlen(end_color_code);


### PR DESCRIPTION
Stderrred doesn't work right if stderr contains escape sequences (one example is gcc). In that case only the initial part of the error message is red.  This can be fixed by parsing the output looking for escape sequences (specifically "end style" sequences), but that is complex.  Better would be for the terminal to understand a special escape sequence pair to delimit error messages.  [DomTerm](https://domterm.org) defines such a pair of sequences.

Another advantage of a distinct escape sequence is that you can style it - even retroactively. DomTerm (being web-based) uses CSS, so you can use whatever style you want.

Note setting STDERRED_ESC_CODE is insufficient as it doesn't override the `end_color_code`.  Plus it is nicer if it is automatic.  An alternative way to deal with this would be to allow STDERRED_ESC_CODE to optionally contain both the `start_color_code` and the `end_color_code`, perhaps separated by a newline.