### PR TITLE
Fix `tmux` text being always red

### DIFF
--- a/src/stderred.c
+++ b/src/stderred.c
@@ -38,6 +38,8 @@ bool is_valid_env = false;
 
 __attribute__((constructor, visibility ("hidden"))) void init() {
   if (!strcmp("bash", PROGRAM_NAME)) return;
+  /* "tmux" spawns subshells with argv[0] prefixed with a '-', e.g. "-bash" */
+  if (PROGRAM_NAME && PROGRAM_NAME[0] == '-' && PROGRAM_NAME[1] != '\0') return;
   if (!isatty(STDERR_FILENO)) return;
 
   char *blacklist;


### PR DESCRIPTION
`tmux` (https://github.com/tmux/tmux/wiki) is a terminal multiplexer,
like `screen`. It spawns its terminals with `argv[0]` prefixed with a
'-', thus breaking `stderred`'s early return on `bash` encounter. This
leads to normal text being always red.

When `PROGRAM_NAME` matches the '-%s' format pattern, treat it as a
shell and return early.

Refer to https://github.com/tmux/tmux/blob/c9d482ab489d5d57d481858091608ee1b32e46ab/window.c#L993
and to https://github.com/tmux/tmux/commit/22d1b9412e52c98cbdf52a3a5185a416c6d26c64.

Fixes https://github.com/sickill/stderred/issues/52