### PR TITLE
Fix shadowing of functions named `init`

### DIFF
--- a/src/stderred.c
+++ b/src/stderred.c
@@ -36,7 +36,7 @@ size_t end_color_code_size;
 #define COLORIZE(fd) (is_valid_env && fd == STDERR_FILENO)
 bool is_valid_env = false;
 
-__attribute__((constructor)) void init() {
+__attribute__((constructor, visibility ("hidden"))) void init() {
   if (!strcmp("bash", PROGRAM_NAME)) return;
   if (!isatty(STDERR_FILENO)) return;
 


### PR DESCRIPTION
Closes #71

```
LD_PRELOAD=/home/user/src/stderred/build/libstderred.so LD_DEBUG=symbols python centralized.py 2>&1 | grep init
...
1059: symbol=init;  lookup in file=python [0]
1059: symbol=init;  lookup in file=/home/user/src/stderred/build/libstderred.so [0]
1059: symbol=init;  lookup in file=/lib64/libpthread.so.0 [0]
1059: symbol=init;  lookup in file=/lib64/libdl.so.2 [0]
1059: symbol=init;  lookup in file=/lib64/libutil.so.1 [0]
1059: symbol=init;  lookup in file=/lib64/libm.so.6 [0]
1059: symbol=init;  lookup in file=/lib64/libc.so.6 [0]
1059: symbol=init;  lookup in file=/lib64/ld-linux-x86-64.so.2 [0]
1059: symbol=init;  lookup in file=/home/user/.pyenv/versions/tik/lib/python3.7/site-packages/_ecos.cpython-37m-x86_64-linux-gnu.so [0]
...
```