### PR TITLE
Fix #82 

### DIFF
--- a/src/stderred.c
+++ b/src/stderred.c
@@ -13,6 +13,9 @@
   #define GET_ORIGINAL(...)
 #else
   #include <dlfcn.h>
+  #define user_ssize_t ssize_t
+  #define user_addr_t const void *
+  #define user_size_t size_t
   #define FUNC(name) (name)
   #define ORIGINAL(name) original_##name
   #define GET_ORIGINAL(ret, name, ...) \


### PR DESCRIPTION
Use correct argument and return types for `__write_nocancel` on Linux, as read from glibc source here:

https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/write_nocancel.c

Fixes issue #82. Tested on Linux.